### PR TITLE
Documentation of new way of service and connector configuration via ES backend

### DIFF
--- a/docs/administrator_guide/cloud_connectors.rst
+++ b/docs/administrator_guide/cloud_connectors.rst
@@ -61,13 +61,17 @@ that the connector names are case insensitive.
 +-----------------+------------------+----------------------------+
 | Cloud           | Connector Name   | License                    |
 +-----------------+------------------+----------------------------+
-| Amazon EC2      | AWS              | proprietary                |
+| Amazon EC2      | EC2              | proprietary                |
 +-----------------+------------------+----------------------------+
 | CloudSigma      | CloudSigma       | proprietary                |
 +-----------------+------------------+----------------------------+
 | CloudStack      | CloudStack       | open-source (Apache 2.0)   |
 +-----------------+------------------+----------------------------+
+| Microsoft Azure | Azure            | proprietary                |
++-----------------+------------------+----------------------------+
 | OCCI            | OCCI             | open-source (Apache 2.0)   |
++-----------------+------------------+----------------------------+
+| OpenNebula      | OpenNebula       | open-source (Apache 2.0)   |
 +-----------------+------------------+----------------------------+
 | OpenStack       | OpenStack        | open-source (Apache 2.0)   |
 +-----------------+------------------+----------------------------+

--- a/docs/administrator_guide/connectors/azure_connector.rst_
+++ b/docs/administrator_guide/connectors/azure_connector.rst_
@@ -29,8 +29,9 @@ To allow users to take advantage of this connector, you must add one or
 more instances of this connector by either:
 
 1. Using the `UI <#with-the-ui>`__.
-2. Drop a `configuration file <#with-a-configuration-file>`__ and
-   restart the service.
+2. Add a connector instance defined via `configuration file
+   <#with-a-configuration-file>`__ using `ss-config` utility and restart
+   the service.
 
 With the UI
 -----------
@@ -100,20 +101,24 @@ with Azure in the 'West Europe' region:
 
 ::
 
-    $ cat /etc/slipstream/connectors/azure-west-europe.conf
-    cloud.connector.class = azure-west-europe:azure
-    azure-west-europe.quota.vm = 
-    azure-west-europe.max.iaas.workers = 20
-    azure-west-europe.native-contextualization = linux-only
-    azure-west-europe.service.region = West Europe
-    azure-west-europe.orchestrator.instance.type = Small
-    azure-west-europe.orchestrator.imageid = TODO
-    azure-west-europe.orchestrator.ssh.username =
-    azure-west-europe.orchestrator.ssh.password = 
+    {
+    :id "connector/azure-west-europe"
+    :cloudServiceType "azure"
+
+    :maxIaasWorkers 20
+    :quotaVm ""
+    :orchestratorImageid "TODO"
+
+    :nativeContextualization "linux-only"
+    :orchestratorSSHUsername ""
+    :orchestratorSSHPassword ""
+    :serviceRegion "West Europe"
+    :orchestratorInstanceType "Small"
+    }
 
 You can find a detailed description of each parameter as well as an
 explaination of how to find the right value of them in the
-```Parameters`` <#parameters>`__ paragraph below.
+`Parameters <#parameters>`__ paragraph below.
 
 Parameters
 ----------

--- a/docs/administrator_guide/connectors/cloudstack_connector.rst
+++ b/docs/administrator_guide/connectors/cloudstack_connector.rst
@@ -28,13 +28,14 @@ To allow users to take advantage of this connector, you must add one or
 more instances of this connector by either:
 
 1. Using the `UI <#with-the-ui>`__.
-2. Drop a `configuration file <#with-a-configuration-file>`__ and
-   restart the service.
+2. Add a connector instance defined via `configuration file
+   <#with-a-configuration-file>`__ using `ss-config` utility and restart
+   the service.
 
 With the UI
 -----------
 
-Instanciate one or more instances of the connector
+Instantiate one or more instances of the connector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once logged-in with a privileged user (e.g. *super*), open the
@@ -85,7 +86,7 @@ connector is to communicate with the IaaS cloud endpoint.
 
 You can find a detailed description of each parameter as well as an
 explaination of how to find the right value of them in the
-```Parameters`` <#parameters>`__ paragraph below.
+`Parameters <#parameters>`__ paragraph below.
 
 With a Configuration File
 -------------------------
@@ -93,34 +94,40 @@ With a Configuration File
 Please see :ref:`dg-cfg-files` for details about this method of
 configuration.
 
-Here is an example, which will configure the CloudStack connector to
-interact with Exoscale:
+Here is an example, which will configure the Exoscale's flavour of CloudStack
+connector to interact with Exoscale:
 
 ::
 
-    > cat /etc/slipstream/connectors/exoscale-ch-gva.conf
-    cloud.connector.class = exoscale-ch-gva:cloudstack
-    exoscale-ch-gva.endpoint = https://api.exoscale.ch/compute
-    exoscale-ch-gva.zone = CH-GV2
-    exoscale-ch-gva.quota.vm = 20
-    exoscale-ch-gva.orchestrator.imageid = 605d1ad4-b3b2-4b60-af99-843c7b8278f8
-    exoscale-ch-gva.orchestrator.instance.type = Micro
-    exoscale-ch-gva.orchestrator.ssh.password =
-    exoscale-ch-gva.orchestrator.ssh.username =
-    exoscale-ch-gva.native-contextualization = linux-only
-    exoscale-ch-gva.max.iaas.workers = 20
+    {
+    :id "connector/exoscale-ch-gva"
+    :cloudServiceType "exoscale"
+
+    :endpoint "https://api.exoscale.ch/compute"
+    :zone "CH-GVA-2"
+    :maxIaasWorkers 20
+    :quotaVm "20"
+    :orchestratorImageid "Linux Ubuntu 14.04 LTS 64-bit"
+    :orchestratorInstanceType "Micro"
+    :orchestratorDisk "10G"
+    :orchestratorSSHUsername ""
+    :orchestratorSSHPassword ""
+    :securityGroups "slipstream_managed"
+    :nativeContextualization "linux-only"
+    :updateClientURL "https://<SS hostname>/downloads/exoscaleclient.tgz"
+    }
 
 You can find a detailed description of each parameter as well as an
 explaination of how to find the right value of them in the
-```Parameters`` <#parameters>`__ paragraph below.
+`Parameters <#parameters>`__ paragraph below.
 
 Parameters
 ----------
 
-*Note: All the CloudStack API examples come from
+**Note:** All the CloudStack API examples come from
 `cloudmonkey <https://cwiki.apache.org/confluence/display/CLOUDSTACK/CloudStack+cloudmonkey+CLI>`__
 configured with `Exoscale Open Cloud
-API <https://community.exoscale.ch/api/compute/>`__ endpoint.*
+API <https://community.exoscale.ch/api/compute/>`__ endpoint.
 
 Zone
 ~~~~

--- a/docs/administrator_guide/connectors/ec2_connector.rst
+++ b/docs/administrator_guide/connectors/ec2_connector.rst
@@ -42,8 +42,9 @@ To allow users to take advantage of this connector, you must add one or
 more instances of this connector by either:
 
 1. Using the `UI <#with-the-ui>`__.
-2. Drop a `configuration file <#with-a-configuration-file>`__ and
-   restart the service.
+2. Add a connector instance defined via `configuration file
+   <#with-a-configuration-file>`__ using `ss-config` utility and restart
+   the service.
 
 With the UI
 -----------
@@ -103,7 +104,6 @@ explaination of how to find the right value of them in the
 
 With a Configuration File
 -------------------------
-
 Please see :ref:`dg-cfg-files` for details about this method of
 configuration.
 
@@ -112,19 +112,23 @@ with the region eu-central-1:
 
 ::
 
-    > cat /etc/slipstream/connectors/ec2-eu-central-1.conf
-    cloud.connector.class = ec2-eu-central-1:ec2
-    ec2-eu-central-1.security.group = default
-    ec2-eu-central-1.update.clienturl = https://<slipstream-ip>/downloads/ec2client.tgz
-    ec2-eu-central-1.orchestrator.instance.type = t2.micro
-    ec2-eu-central-1.region = eu-central-1
-    ec2-eu-central-1.quota.vm = 
-    ec2-eu-central-1.max.iaas.workers = 20
-    ec2-eu-central-1.orchestrator.imageid = ami-accff2b1
+    {
+    :id "connector/ec2-eu-central-1"
+    :cloudServiceType "ec2"
+
+    :maxIaasWorkers 20
+    :quotaVm "20"
+    :orchestratorImageid "ami-accff2b1"
+
+    :securityGroups "default"
+    :updateClientURL "https://<SS hostname>/downloads/ec2client.tgz"
+    :orchestratorInstanceType "t2.micro"
+    :region "eu-central-1"
+    }
 
 You can find a detailed description of each parameter as well as an
 explaination of how to find the right value of them in the
-```Parameters`` <#parameters>`__ paragraph below.
+`Parameters <#parameters>`__ paragraph below.
 
 Parameters
 ----------

--- a/docs/administrator_guide/connectors/occi_connector.rst
+++ b/docs/administrator_guide/connectors/occi_connector.rst
@@ -93,8 +93,9 @@ To allow users to take advantage of this connector, you must add one or
 more instances of this connector by either:
 
 1. Using the `UI <#with-the-ui>`__.
-2. Drop a `configuration file <#with-a-configuration-file>`__ and
-   restart the service.
+2. Add a connector instance defined via `configuration file
+   <#with-a-configuration-file>`__ using `ss-config` utility and restart
+   the service.
 
 With the UI
 -----------
@@ -155,18 +156,21 @@ With a configuration file
 Please see :ref:`dg-cfg-files` for details about this method of
 configuration.
 
-Here is an example, which will configure the EC2 connector to interact
-with the region eu-central-1:
+Here is an example, which will configure the OCCI connector to interact
+with fedcloud-egi-eu cloud site:
 
 ::
 
-    > cat /etc/slipstream/connectors/fedcloud-egi-eu.conf
-    cloud.connector.class = fedcloud-egi-eu:occi
+    {
+    :id "connector/fedcloud-egi-eu"
+    :cloudServiceType "occi"
+
     <TODO>
+    }
 
 You can find a detailed description of each parameter as well as an
 explaination of how to find the right value of them in the
-```Parameters`` <#parameters>`__ paragraph below.
+`Parameters <#parameters>`__ paragraph below.
 
 Parameters
 ----------

--- a/docs/administrator_guide/connectors/openstack_connector.rst
+++ b/docs/administrator_guide/connectors/openstack_connector.rst
@@ -20,8 +20,9 @@ To allow users to take advantage of this connector, you must add one or
 more instances of this connector by either:
 
 1. Using the `UI <#with-the-ui>`__.
-2. Drop a `configuration file <#with-a-configuration-file>`__ and
-   restart the service.
+2. Add a connector instance defined via `configuration file
+   <#with-a-configuration-file>`__ using `ss-config` utility and restart
+   the service.
 
 With the UI
 -----------
@@ -91,25 +92,29 @@ interact with Ultimum:
 
 ::
 
-    $ cat /etc/slipstream/connectors/ultimum-cz1.conf
-    cloud.connector.class = ultimum-cz1:openstack
-    ultimum-cz1.quota.vm = 
-    ultimum-cz1.max.iaas.workers = 20
-    ultimum-cz1.service.name = nova
-    ultimum-cz1.native-contextualization = linux-only
-    ultimum-cz1.service.region = RegionOne
-    ultimum-cz1.network.private = private
-    ultimum-cz1.orchestrator.instance.type = Basic
-    ultimum-cz1.service.type = compute
-    ultimum-cz1.orchestrator.ssh.username =
-    ultimum-cz1.orchestrator.imageid = 970da64c-c4be-4bb3-879b-75433751e71f
-    ultimum-cz1.network.public = public
-    ultimum-cz1.endpoint = https://console.ulticloud.com:5000/v2.0/tokens
-    ultimum-cz1.orchestrator.ssh.password = 
+    {
+    :id "connector/ultimum-cz1"
+    :cloudServiceType "openstack"
+
+    :maxIaasWorkers 20
+    :quotaVm ""
+    :orchestratorImageid "970da64c-c4be-4bb3-879b-75433751e71f"
+
+    :serviceName "nova"
+    :nativeContextualization "linux-only"
+    :serviceRegion "RegionOne"
+    :networkPublic "public"
+    :networkPrivate "private"
+    :orchestratorInstanceType "Basic"
+    :serviceType "compute"
+    :orchestratorSSHUsername ""
+    :orchestratorSSHPassword ""
+    :endpoint "https://console.ulticloud.com:5000/v2.0/tokens"
+    }
 
 You can find a detailed description of each parameter as well as an
 explaination of how to find the right value of them in the
-```Parameters`` <#parameters>`__ paragraph below.
+`Parameters <#parameters>`__ paragraph below.
 
 Parameters
 ----------

--- a/docs/administrator_guide/connectors/stratuslab_connector.rst
+++ b/docs/administrator_guide/connectors/stratuslab_connector.rst
@@ -42,8 +42,9 @@ To allow users to take advantage of this connector, you must add one or
 more instances of this connector by either:
 
 1. Using the `UI <#with-the-ui>`__.
-2. Drop a `configuration file <#with-a-configuration-file>`__ and
-   restart the service.
+2. Add a connector instance defined via `configuration file
+   <#with-a-configuration-file>`__ using `ss-config` utility and restart
+   the service.
 
 With the UI
 -----------
@@ -105,17 +106,20 @@ project:
 
 ::
 
-    $ cat /etc/slipstream/connectors/stratuslab.conf
-    cloud.connector.class = stratuslab:stratuslab
-    stratuslab.max.iaas.workers = 20
-    stratuslab.update.clienturl = http://<slipstream-ip>/downloads/stratuslabclient.tgz
-    stratuslab.messaging.endpoint = https://pdisk.lal.stratuslab.eu/pdisk
-    stratuslab.pdisk.endpoint = https://pdisk.lal.stratuslab.eu/pdisk
-    stratuslab.orchestrator.imageid = N-Bu1h1jt3K8ODnCTw4JiyPaH5k
-    stratuslab.quota.vm = 10
-    stratuslab.endpoint = https://cloud.lal.stratuslab.eu/one-proxy/xmlrpc
-    stratuslab.marketplace.endpoint = https://marketplace.stratuslab.eu/marketplace
-    stratuslab.orchestrator.instance.type = m1.small
+    {
+    :id "connector/stratuslab"
+    :cloudServiceType "stratuslab"
+
+    :maxIaasWorkers 20
+    :quotaVm "10"
+    :orchestratorImageid "N-Bu1h1jt3K8ODnCTw4JiyPaH5k"
+
+    :endpoint "https://cloud.lal.stratuslab.eu/one-proxy/xmlrpc"
+    :updateClientURL "http://<slipstream-ip>/downloads/stratuslabclient.tgz"
+    :pdiskEndpoint "https://pdisk.lal.stratuslab.eu/pdisk"
+    :marketplaceEndpoint "https://marketplace.stratuslab.eu/marketplace"
+    :orchestratorInstanceType "m1.small"
+    }
 
 Configure Native Images for This Connector Instance
 ---------------------------------------------------

--- a/docs/administrator_guide/connectors/vcloud_connector.rst
+++ b/docs/administrator_guide/connectors/vcloud_connector.rst
@@ -37,8 +37,9 @@ To allow users to take advantage of this connector, you must add one or
 more instances of this connector by either:
 
 1. Using the `UI <#with-the-ui>`__.
-2. Drop a `configuration file <#with-a-configuration-file>`__ and
-   restart the service.
+2. Add a connector instance defined via `configuration file
+   <#with-a-configuration-file>`__ using `ss-config` utility and restart
+   the service.
 
 With the UI
 -----------
@@ -108,19 +109,23 @@ interact with a vCloud provider:
 
 ::
 
-    $ cat /etc/slipstream/connectors/my-vcloud.conf
-    cloud.connector.class = my-vcloud:vcloud
-    deac-lv1.quota.vm = 
-    deac-lv1.orchestrator.instance.type = 1,1
-    deac-lv1.virtual.datacenter.name = VDC-01
-    deac-lv1.orchestrator.imageid = Ubuntu_12_04
-    deac-lv1.update.clienturl = https://<slipstream-ip>/downloads/vcloudclient.tgz
-    deac-lv1.endpoint = https://vcloud.provider.com/api
-    deac-lv1.max.iaas.workers = 1
+    {
+    :id "connector/my-vcloud"
+    :cloudServiceType "vcloud"
+
+    :maxIaasWorkers 1
+    :quotaVm ""
+    :orchestratorImageid "Ubuntu_12_04"
+
+    :orchestratorInstanceType "1,1"
+    :virtualDatacenterName "VDC-01"
+    :updateClientURL "https://<slipstream-ip>/downloads/vcloudclient.tgz"
+    :endpoint "https://vcloud.provider.com/api"
+    }
 
 You can find a detailed description of each parameter as well as an
 explaination of how to find the right value of them in the
-```Parameters`` <#parameters>`__ paragraph below.
+`Parameters <#parameters>`__ paragraph below.
 
 Parameters
 ----------

--- a/docs/administrator_guide/introduction.rst
+++ b/docs/administrator_guide/introduction.rst
@@ -83,9 +83,13 @@ The following table shows the availability of the cloud connectors.
 +-------------------------+---------------+----------------+
 | IBM Smart Cloud Entry   | proprietary   | coming soon    |
 +-------------------------+---------------+----------------+
-| Microsoft IaaS Azure    | proprietary   | coming soon    |
+| Microsoft IaaS Azure    | proprietary   | available      |
++-------------------------+---------------+----------------+
+| NuvlaBox                | proprietary   | available      |
 +-------------------------+---------------+----------------+
 | OCCI                    | open source   | available      |
++-------------------------+---------------+----------------+
+| OpenNebula              | open source   | available      |
 +-------------------------+---------------+----------------+
 | OpenStack               | open source   | available      |
 +-------------------------+---------------+----------------+
@@ -95,6 +99,8 @@ The following table shows the availability of the cloud connectors.
 +-------------------------+---------------+----------------+
 | VMWare vCloud           | proprietary   | available      |
 +-------------------------+---------------+----------------+
+
+All open-source connectors are licensed with Apache 2.0.
 
 SlipStream Edition
 ------------------

--- a/docs/administrator_guide/prerequisites.rst
+++ b/docs/administrator_guide/prerequisites.rst
@@ -3,9 +3,9 @@ Prerequisities
 
 The SlipStream server has a standard, n-tier web application
 architecture: the application runs within a Java web application
-container and stores data within an SQL database. Consequently, many
-administrators will be familiar with its configuration needs and modest
-resource requirements.
+container and stores data within SQL and NoSQL (document oriented)
+databases. Consequently, many administrators will be familiar with
+its configuration needs and modest resource requirements.
 
 Software Requirements
 ---------------------
@@ -26,7 +26,7 @@ Machine (JVM) running the service. Similarly 10-20 GB of disk space
 should be sufficient for initial use.
 
 As with any service, the resource requirements for the server will
-increase with the number of users and with the number of system
+increase with the number of users and with the number of user application
 deployments. Use a larger machine if you expect particularly large scale
 or intense use of the service.
 
@@ -41,9 +41,9 @@ may also allow access to the HTTP port.
 
 To administer and monitor the machine running the SlipStream service,
 you may also want to have the SSH port (22) and the Nagios NRPE port
-(5666) open to your administrators' machines.
+(5666) open to your administrators' and monitoring machines.
 
-The configured SlipStream connectors act as clients of the correponding
+The configured SlipStream connectors act as clients of the corresponding
 cloud service provider. Consequently, the server must also have
 *outgoing* access to the underlying cloud service endpoints. The ports
 used vary depending on the cloud service provider.
@@ -56,6 +56,6 @@ Cloud Requirements
 ------------------
 
 SlipStream is a cloud deployment engine and requires access to at least
-one supported cloud infrastucture. See the list of supported clouds and
+one supported cloud infrastructure. See the list of supported clouds and
 conditions on the associated cloud plugin to select the cloud(s) you
 will be making available through your SlipStream instance.

--- a/docs/administrator_guide/quick_installation.rst
+++ b/docs/administrator_guide/quick_installation.rst
@@ -11,20 +11,23 @@ This script will do the following actions on your machine:
 -  Configure nginx yum repository
 -  Install SlipStream in /opt/slipstream
 -  Install HSQLDB in /opt/hsqldb
+-  Install Elasticsearch NoSQL datastore
 -  Install nginx
 -  Install some other dependencies with yum and python-pip
 -  Disable SElinux
--  Configure nginx, HSQLDB and SlipStream
+-  Configure nginx, HSQLDB, Elasticsearch and SlipStream
 -  Replace the firewall configuration with the following:
--  Allow all outgoing packets
--  Allow loopback connections
--  Allow incoming ICMP requests
--  Allow incoming SSH connections (port 22)
--  Allow incoming HTTP connections (port 80)
--  Allow incoming HTTPS connections (port 443)
--  Deny all other incoming connections
--  Deny forwarding
--  Start nginx, HSQLDB and SlipStream
+
+   -  Allow all outgoing packets
+   -  Allow loopback connections
+   -  Allow incoming ICMP requests
+   -  Allow incoming SSH connections (port 22)
+   -  Allow incoming HTTP connections (port 80)
+   -  Allow incoming HTTPS connections (port 443)
+   -  Deny all other incoming connections
+   -  Deny forwarding
+
+-  Start nginx, HSQLDB, Elasticsearch and SlipStream
 
 These instructions assume that you will be using the prebuilt binary
 packages for SlipStream. If you want to build your own packages from the
@@ -110,6 +113,7 @@ to the dedicated :ref:`configuration files documentation page
 
 This will allow you to define configuration for:
 
+-  Service
 -  Connectors
 -  Modules
 -  Users
@@ -158,7 +162,7 @@ The Authorization callback URL must be <SlipStream end point>/auth/callback-gith
 You will obtain a Github client ID and a Github secret (see next).
 
 Then, edit authentication server configuration (/opt/slipstream/ssclj/resources/db.spec) with these
-Github credentials. (Do not forget to provide values for :auth-server and :main-server entries).
+Github credentials. (Do not forget to provide values for ``:auth-server`` and ``:main-server entries``).
 
 Finally, restart ssclj service.
 

--- a/docs/developer_guide/configuration.rst
+++ b/docs/developer_guide/configuration.rst
@@ -9,6 +9,31 @@ configure it.
 You can either use the web UI that you just started, or use
 :ref:`configuration files <dg-cfg-files>`.
 
+Service
+-------
+
+SlipStream global service level behaviour can be configured either
+via UI or by using ``ss-config`` utility. The latter allows to configure
+the service from CLI utilising configuration file(s).
+
+From version 3.15, SlipStream no longer reads service and/or connector
+configuration files, which used to be located in ``/etc/slipstream/``
+on the machine where the SlipStream service runs.
+Instead, to bootstrap the service with a required predefined
+configuration, it is now required to use ``ss-config`` utility with
+service and/or connector configuration files.
+
+Given the configuration file(s), ``ss-config`` utility connects to
+a defined Elasticsearch instance and adds/updates the respective
+configuration.  For more deatils on the usage of ``ss-config`` see
+:ref:`dg-cfg-ss-config`.
+
+The new way of configuration allows to remove the state and thus
+eliminate the need to read it in on the hosts running SlipStream
+service business logic.  This greatly simplifies deployment and
+maintenance of the service in a scalable or redundant setup for
+throughput and/or high availability.
+
 User(s)
 -------
 
@@ -32,8 +57,8 @@ Connector(s)
 Once the server is up and running you need to configure a connector
 before trying to deploy a module. Out of the box, using the local
 connector is the easiest way to get started. To do so, navigate to the
-`server configuration page <http://localhost:8080/configuration>`__ and
-define a cloud connector instance in the SlipStream Basics section:
+server configuration page ``https://<slipstream>/configuration``
+and define a cloud connector instance in the SlipStream Basics section:
 
 ::
 
@@ -46,6 +71,8 @@ isn't given, it defaults to the connector name.
 
 For configuration of other cloud connectors, check our
 `blog <http://sixsq.com/blog/index.html>`__.
+
+**FIXME: rewrite!!!!!**
 
 Alternatively, you can create new connector instance by :ref:`dropping
 connector configuration files in your configuration directory

--- a/docs/developer_guide/configuration_files.rst
+++ b/docs/developer_guide/configuration_files.rst
@@ -8,24 +8,129 @@ system. This is great, but you probably want a few basic configuration
 items loaded for your instance to be useable and useful.
 
 The following instructions describe how you can drive the entire
-configuration of SlipStream by simply dropping a few files on the file
-system and restarting the service.
-
-The configuration files will only be loaded once, on an empty system. It
-is therefore safe to restart the SlipStream service with modified
-configuration files. A specific post request can be invoked to force a
-reload of the files.
+configuration of SlipStream by using ``ss-config`` utility with
+configuration files and restarting the service.
 
 .. warning::
 
     If your SlipStream server is already started, don't forget to
-    restart it for the configuration files to be loaded.
+    restart it after the configuration was updated with ``ss-config``.
+
+
+.. _dg-cfg-ss-config:
+
+SlipStream configuration utility
+--------------------------------
+
+Below is the help message printed by the SlipStream configuration utility ``ss-config``.
+
+::
+
+    $ ss-config -h
+
+    Adds or updates different parts of the SlipStream service configuration in DB.
+
+    Usage: [options] <list-of-files>
+
+    Options:
+      -t, --template TEMPLATE       Prints out registered template by name.
+      -l, --list                    Lists available templates.
+      -p, --persisted               Lists resources persisted in DB.
+      -r, --resource RESOURCE  #{}  Prints out persisted resource document(s) by name.
+      -h, --help
+
+    Arguments:
+      <list-of-files>    list of edn files with configurations.
+
+
+      Ensure :id key with a corresponding resource name is present in each configuration.
+      Connector configuration must contain :cloudServiceType key, which corresponds to
+      the connector name.
+
+      ES_HOST and ES_PORT should be exported in the environment for the utility
+      to be able to connect to Elasticsearch.
+
+The utility works the way that it takes as input specific resource(s)
+configuration file(s), validates them and adds or updates the respective
+entries in the DB.  Currently the backend used as DB is Elasticsearch.
+It is required to provide its coordinates via exporting ``ES_HOST`` and
+``ES_PORT`` environment variables.
+
+The configuration files that the utility expects are in so called ``edn``
+format (see `<https://github.com/edn-format/edn>`__).  Here is an example
+to show a valid syntax of such file
+
+::
+
+    {
+     ; Comment.
+     ; Commas separating key/value pairs are optional and can be omitted.
+     :keyString  "value",
+     :keyInteger 123
+     :keyVector  ["a" "b" "c"]
+    }
+
+Each configurable resource has a template associated with it.  Templates,
+available for ``ss-config``, can be printed with ``-l`` option
+
+::
+
+    $ ss-config -l
+    List of accessible templates.
+    - templates for 'connector'
+    connector-template/openstack
+    - templates for 'configuration'
+    configuration-template/slipstream
+
+The availability of template for a particular resource is a prerequisite
+for ``ss-config`` to be able to work with the resource's configuration
+due to the requirement for the utility to be able to validate the provided
+configuration against a predefined schema that comes with the template.
+
+Running with ``-t configuration-template/slipstream`` prints out the
+service configuration template with all available parameters and their
+respective types.
+
+::
+
+    $ ss-config -t configuration-template/slipstream
+    {:reportsLocation "/var/tmp/slipstream/reports",
+     :prsEndpoint "http://localhost:8203/filter-rank",
+     :service "slipstream",
+     :connectorOrchPrivateSSHKey "/opt/slipstream/server/.ssh/id_rsa",
+     :clientBootstrapURL "https://localhost/downloads/slipstream.bootstrap",
+     :cloudConnectorClass "",
+     :meteringEndpoint "http://localhost:2005",
+     :mailHost "smtp.example.com",
+     :mailPort 465,
+     :registrationEnable true,
+     :mailSSL true,
+     :registrationEmail "register@sixsq.com",
+     :prsEnable true,
+     :serviceURL "https://localhost",
+     :meteringEnable false,
+     :supportEmail "support@example.com",
+     :clientURL "https://localhost/downloads/slipstreamclient.tgz",
+     :connectorLibcloudURL "https://localhost/downloads/libcloud.tgz",
+     :slipstreamVersion "3.15-SNAPSHOT",
+     :id "configuration-template/slipstream",
+     :quotaEnable true,
+     :mailDebug true,
+     :connectorOrchPublicSSHKey "/opt/slipstream/server/.ssh/id_rsa.pub",
+     :mailUsername "mailer",
+     :serviceCatalogEnable false,
+     :mailPassword "change-me"}
+
+The printed out template can serve as a basis for creating edn configuration
+file.  Please see :ref:`dg-cfg-main-config` and
+:ref:`dg-cfg-files-connector` for documentation on service and
+connector configuration files respectively.
 
 File System Structure
 ---------------------
 
-Initially, SlipStream will look for configuration files in the file
-system to load. Typically, the loader will look for files in the
+Initially, SlipStream will look for some of the configuration files in
+the file system to load. Typically, the loader will look for files in the
 following locations, stopping at the first occurrence:
 
 ::
@@ -37,10 +142,6 @@ Inside this structure of the expected configuration is as follows:
 
 +---------------------------+------------------------------------------+
 | Configuration file        | Meaning                                  |
-+---------------------------+------------------------------------------+
-| ``./slipstream.conf``     | Main configuration file                  |
-+---------------------------+------------------------------------------+
-| ``./connectors/*.conf``   | Connector specific configuration files   |
 +---------------------------+------------------------------------------+
 | ``./modules/*.xml``       | Module definition files                  |
 +---------------------------+------------------------------------------+
@@ -54,56 +155,198 @@ Inside this structure of the expected configuration is as follows:
 Note that these files are not created by default during a standard
 installation.
 
+.. _dg-cfg-main-config:
+
 Main Configuration File
 -----------------------
 
-The main configuration file is normally placed in /etc/slipstream when
-performing a standard installation. The default values are taken from
-the `system
-default <https://github.com/slipstream/SlipStreamServer/blob/master/jar-connector/src/main/resources/com/sixsq/slipstream/configuration/default.config.properties>`__
-shipped with SlipStream.
+When the standard installation is performed, the service is started with
+a default configuration that gets persisted in the database.
 
-If you want to override these defaults, a good place to start is from
-the `system
-default <https://github.com/slipstream/SlipStreamServer/blob/master/jar-connector/src/main/resources/com/sixsq/slipstream/configuration/default.config.properties>`__
-file, that you can modify and drop in one of the standard location (see
-previous section).
+When you want to override these defaults, a good place to start is to save
+the output of ``ss-config -t configuration-template/slipstream`` to a file
+
+::
+
+    $ ss-config -t configuration-template/slipstream > slipstream-config.edn
+
+update value of ``:id`` parameter and remove ``-template`` from it so that
+it becomes ``configuration/slipstream```; edit the values of the parameters
+you want to modify and run
+
+::
+
+    $ export ES_HOST=localhost; export ES_PORT=9300
+    $ ss-config slipstream-config.edn
+
+which will push the new configuration to the Elasticsearch backend.
+
+When the configuration is already available in the database and your goal
+is just to "edit" some parameters, it's enough to define only some of the
+parameter in the configuration file.  E.g,:
+
+::
+
+    $ cat slipstream.edn
+    {
+     :id "configuration/slipstream"
+     :prsEnable true
+     :prsEndpoint "http://my-ranking.service/filter-rank"
+     :quotaEnable false
+     }
+    $ ss-config slipstream-config.edn
 
 .. warning::
 
-    Do not forget to rename the default file to ``slipstream.conf``.
+    Do not forget to remove ``-template`` in the value of the ``:id``
+    parameter.
+
+To edit some parameters of an existing configuration, you can
+save the current configuration to a file, edit it and then
+commit the changes by following the steps below.
+
+::
+
+   $ ss-config -r configuration/slipstream > configuration-slipstream.edn
+   $
+   $ # edit and save configuration-slipstream.edn file
+   $
+   $ ss-config configuration-slipstream.edn
+
+All this can be done without SlipStream service running.
+
+.. warning::
+
+    Make sure ``:id`` parameter is in the file.
+
 
 .. _dg-cfg-files-connector:
 
 Connector Configuration Files
 -----------------------------
 
-Each connector can be configured by simply dropping a configuration file
-in the ``./connectors/`` directory. While the same can be achieved using
-the main configuration file, we recommend you split your connector
-configuration in separate files. This method is also more configuration
-management tool friendly, such as Puppet, Chef or Ansible.
+New connectors can be instantiated and configured by using ``ss-config``
+utility.
 
-The connector configuration file must include the
-``cloud.connector.class`` and the name given to the connector instance
-must be used to qualify all other configuration parameter. Here is an
-example of a connector file to configure the Exoscale cloud:
+To instantiate a new instance of a connector, one has to know the name
+of the connector and make sure that it is installed.  It's possible to
+find what connectors are installed and available for instantiation by
+checking the list of templates known to ``ss-config`` with
 
 ::
 
-    cloud.connector.class = exoscale-ch-gva:cloudstack
-    exoscale-ch-gva.endpoint = https://api.exoscale.ch/compute
-    exoscale-ch-gva.zone = CH-GV2
-    exoscale-ch-gva.quota.vm = 20
-    exoscale-ch-gva.orchestrator.imageid = 605d1ad4-b3b2-4b60-af99-843c7b8278f8
-    exoscale-ch-gva.orchestrator.instance.type = Micro
-    exoscale-ch-gva.native-contextualization = linux-only
+    $ ss-config -l
+    List of accessible templates.
+    - templates for 'connector'
+    connector-template/stratuslabiter
+    connector-template/stratuslab
+    connector-template/openstack
+    connector-template/cloudstack
+    connector-template/cloudstackadvancedzone
+    - templates for 'configuration'
+    configuration-template/slipstream
+    $
 
-.. warning:: 
+Copy the name of the desired connector and get its template by
 
-    Do not forget to have a ``cloud.connector.class`` key in each file.
+::
 
-You can have as many connector configuration files as you wish.
+    $ ss-config -t connector-template/openstack > connector-openstack.edn
+    $ cat connector-openstack.edn
+    {:networkPrivate "",
+     :serviceRegion "RegionOne",
+     :identityVersion "v2",
+     :securityGroups "slipstream_managed",
+     :cloudServiceType "openstack",
+     :orchestratorInstanceType "Basic",
+     :floatingIps false,
+     :networkPublic "",
+     :updateClientURL "",
+     :serviceType "compute",
+     :quotaVm "20",
+     :nativeContextualization "linux-only",
+     :id "connector-template/openstack",
+     :orchestratorSSHUsername "",
+     :maxIaasWorkers 5,
+     :serviceName "",
+     :orchestratorImageid "",
+     :endpoint "",
+     :orchestratorSSHPassword ""}
+
+Next step is to define an instance name for the connector and update
+the values of the parameters.  Edit the file and modify ``:id`` parameter
+by removing ``-template`` and writing the instance name after ``/``.  Keep
+``:cloudServiceType`` unchanged.
+
+::
+
+    :id connector/my-openstack
+    :cloudServiceType "openstack"
+
+Then, change other parameters like ``:endpoint`` etc.  When finished, run
+
+::
+
+    $ export ES_HOST=localhost; export ES_PORT=9300
+    $ ss-config connector-openstack.edn
+    Adding connector connector/my-openstack for the first time.
+    Updating :cloudConnectorClass parameter with - my-openstack:openstack
+    Adding configuration for the first time.
+    $
+
+This will add a new instance of the connector and if the service
+configuration was missing it will add the default one as well.
+
+To edit some parameters of an existing connector instance, you can list
+already persisted connector instances by
+
+::
+
+    $ ss-config -p
+    List of persisted resources.
+    - resources for 'configuration'
+    configuration/slipstream
+    - resources for 'connector'
+    connector/my-openstack
+    connector/stratuslab
+    $
+
+then, save the required for editing resource to a file by
+
+::
+
+    $ ss-config -r connector/my-openstack > connector-my-openstack.edn
+    $  cat connector-my-openstack.edn
+    ;;; Resource: connector/my-openstack
+    {:networkPrivate "private",
+     :serviceRegion "RegionOne",
+     :identityVersion "v3",
+     :securityGroups "slipstream_managed",
+     :orchestratorInstanceType "Basic",
+     :floatingIps false,
+     :networkPublic "public",
+     :updateClientURL "https://my-slipstream/downloads/openstackclient.tgz",
+     :serviceType "compute",
+     :quotaVm "20",
+     :nativeContextualization "linux-only",
+     :orchestratorSSHUsername "",
+     :maxIaasWorkers 5,
+     :serviceName "",
+     :orchestratorImageid "",
+     :endpoint "http://my-openstack/openstack",
+     :orchestratorSSHPassword ""}
+
+edit parameters in the file and commit the changes by running
+
+::
+
+    $ ss-config connector-my-openstack.edn
+
+All this can be done without SlipStream service running.
+
+.. warning::
+
+    Make sure ``:id`` and ``:cloudServiceType`` keys are in the file.
 
 .. warning::
 

--- a/docs/developer_guide/configuration_files.rst
+++ b/docs/developer_guide/configuration_files.rst
@@ -37,6 +37,7 @@ Below is the help message printed by the SlipStream configuration utility ``ss-c
       -l, --list                    Lists available templates.
       -p, --persisted               Lists resources persisted in DB.
       -r, --resource RESOURCE  #{}  Prints out persisted resource document(s) by name.
+      -e, --edit-kv KEY=VALUE  #{}  Updates or adds key=value in first file from <list-of-files> (other files are ingnored).
       -h, --help
 
     Arguments:
@@ -213,6 +214,20 @@ commit the changes by following the steps below.
    $
    $ ss-config configuration-slipstream.edn
 
+By using ``-e`` option it's possible to update or add parameters in a
+configuration file.  For example:
+
+::
+
+    $ ss-config -e meteringEndpoint=http://1.2.3.4:1234/metering \
+                -e mailUsername=postman \
+                -e invalidKey=bad-key \
+                slipstream.edn
+
+updates ``:meteringEndpoint`` and ``:mailUsername`` parameters to new values,
+and adds a new one ``:invalidKey`` without needing to open the file.  This might
+be handy in atomated editing of the configuration files.
+
 All this can be done without SlipStream service running.
 
 .. warning::
@@ -341,6 +356,20 @@ edit parameters in the file and commit the changes by running
 ::
 
     $ ss-config connector-my-openstack.edn
+
+By using ``-e`` option it's possible to update or add parameters in a
+configuration file.  For example:
+
+::
+
+    $ ss-config -e identityVersion=v2 \
+                -e endpoint=http://another-opentack/openstack \
+                -e invalidKey=bad-key \
+                connector-my-openstack.edn
+
+updates ``:identityVersion`` and ``:endpoint`` parameters to new values, and
+adds a new one ``:invalidKey`` without needing to open the file.  This might
+be handy in atomated editing of the configuration files.
 
 All this can be done without SlipStream service running.
 

--- a/docs/developer_guide/running.rst
+++ b/docs/developer_guide/running.rst
@@ -63,14 +63,90 @@ To start Elastic Search engine, just type (in the ``bin`` directory):
 SlipStream Services
 -------------------
 
-SlipStream is composed of two main services. This section describes how
+SlipStream is composed of a number of services. This section describes how
 to start these services.
 
-Running the Main SlipStream Service
------------------------------------
+Strarting the Ancillary SlipStream Service
+------------------------------------------
+
+This service should be started first and includes additional resources, such
+as ``event`` and ``usage`` resources.  As opposed to the main service, which is
+written in Java, this service is written in Clojure.  The service uses both
+HSQLDB and Elasticsearch, so they should be up and running prior to starting
+the service.
+
+The service should be started from the ``ssclj/jar`` module of
+``SlipStreamServer`` project.
+
+::
+
+   $ cd SlipStreamServer/ssclj/jar
+
+To run the service, export the required environment variables, start Clojure
+REPL with boot and in the REPL run the commands listed below::
+
+    $ export ES_HOST=localhost
+    $ export ES_PORT=9300
+    $ export CONFIG_PATH=db.spec
+
+    $ boot repl
+      boot.user=> (require '[com.sixsq.slipstream.ssclj.app.server :as server :reload true])
+      nil
+      boot.user=> (def stop-fn (server/start 8201))
+      nil
+      boot.user=> ;; when needed, stop with
+      boot.user=> ;; (server/stop stop-fn)
+
+The services will be started on port ``8201``.  You can set it as needed,
+taking into account that it will be required later during the startup of the
+main SlipStream service.
+
+The directory containing the ``db.spec`` file must be on the classpath.  The
+``db.spec`` is the path to the file containing the HSQLDB database definition.
+Typical content looks like::
+
+    {:db {
+      :classname    "org.hsqldb.jdbc.JDBCDriver"
+      :subprotocol  "hsqldb"
+      :subname      "mem://localhost:9012/devresources"
+      :make-pool?   true}}
+
+The service's log file can be found under ``logs/ssclj-.log``
+
+You can add other dependencies to the classpath
+as needed.  This can be done either by editing the list of dependencies in
+``build.boot``::
+
+    21   :dependencies
+    22   #(vec (concat %
+    23                 (merge-defaults
+    24                  ['sixsq/default-deps (get-env :version)]
+    25                  '[[org.clojure/clojure]
+    ...
+    58                    [com.sixsq.slipstream/SlipStreamConnector-OpenStack-conf]
+    59                    ;; added OpenStack connector jar
+
+or providing the dependencies to ``boot`` command as follows::
+
+    $ boot -d com.sixsq.slipstream/SlipStreamConnector-OpenStack-conf:3.17-SNAPSHOT repl
+
+By adding connectors jar to the classpath of the service (as shown above) we
+allow the service to create the connector instances.
+
+Starting Pricing and Ranking Service (PRS)
+------------------------------------------
+
+To start PRS service go to ``SlipStreamServer/jar-prs-service`` and run::
+
+    $ boot run
+
+The service starts on ``localhost:3000`` by default.  Logs go to stdout/err.
+
+Starting the Main SlipStream Service
+------------------------------------
 
 To run the main server, drop into the ``war`` subdirectory in the
-``SlipStreamServer`` module and then use Jetty to run the SlipStream web
+``SlipStreamServer`` project and then use Jetty to run the SlipStream web
 archive (war file).
 
 ::
@@ -94,10 +170,14 @@ the server pointing to source static location as following:
 
 ::
 
+    $ export ES_HOST=localhost
+    $ export ES_PORT=9300
     $ mvn jetty:run-war \
           -Dstatic.content.location=file:../../SlipStreamUI/src/slipstream/ui/views
 
-You can also change the database backend connection using the
+The server makes use of Elasticsearch as database backend, therefore, you see
+the need to set the host and port of Elasticsearch.
+You can also change the main database backend connection using the
 ``persistence.unit``. For example:
 
 ::
@@ -121,41 +201,3 @@ server.
     If you intend to configure your system from configuration files, do
     not start your service just yet and read on.
 
-Running the Ancillary SlipStream Service
-----------------------------------------
-
-This service includes additional resources, such as ``event`` and
-``usage`` resources. As opposed to the main service written in Java,
-this service is written in Clojure.
-
-To run the service from the ``ssclj`` repository, use the jar file that
-contains all of the service dependencies:
-
-::
-
-    /usr/bin/java
-      -Ddb.config.path=<db.spec>
-      -Dlogfile.path=<environment.name>
-      -cp .:target/SlipStreamCljResources-jar-<version>-jar-with-dependencies.jar
-      com.sixsq.slipstream.ssclj.app.main 8201
-
-Changing the name of the generated jar file as needed.
-
-The directory containing the ``db.spec`` file must be on the classpath
-(here it is "``.``\ "). You can add other dependencies to the classpath
-as needed. The service will start on the port 8200 by default or you can
-provide an argument to change the port (port 8201 in the example).
-
-The ``db.spec`` is the path to the file containing the database
-definition (e.g. *config-hsqldb-mem.edn*). Typical content looks like:
-
-::
-
-    {:db {
-      :classname    "org.hsqldb.jdbc.JDBCDriver"
-      :subprotocol  "hsqldb"
-      :subname      "mem://localhost:9012/devresources"
-      :make-pool?   true}}
-
-Note that the log file will be named after the value of
-``environment.name``.


### PR DESCRIPTION
NB! Please don't merge it yet until docu for connectors in TODO is done.

Current changes are
- [x] new way of configuration using `ss-config` utility
- [x] cloudstack connector
- [x] minor updates to other parts of the docu.

TODO:
- [ ] docs/administrator_guide/connectors/ec2_connector.rst
- [ ] docs/administrator_guide/connectors/openstack_connector.rst
- [ ] docs/administrator_guide/connectors/stratuslab_connector.rst

Connected to #97 
